### PR TITLE
Fix puzzle loop state handling and zero counting

### DIFF
--- a/puzzle.py
+++ b/puzzle.py
@@ -66,12 +66,16 @@ class PuzzleBot:
                             color=(0, 255, 255), thickness=4, lineType=cv.LINE_4)
 
         self.tetris.board = board
-        if self.tetris.count_zeros == 0:
+        zeros = self.tetris.count_zeros()
+
+        print(f"[PUZZLE] Freie Felder: {zeros}")
+
+        if zeros == 0:
             self.tetris.first = 0
             self.tetris.second = 0
         else:
             self.tetris.first = 1
-            self.tetris.second = 1
+            self.tetris.second = 1    
 
     def get_image(self):
 
@@ -159,7 +163,7 @@ class PuzzleBot:
             mouse_y = 15 + paint_c*pos[0] + self.PUZZLE_WINDOW_POSITION[1] + self.wincap.offset_y
             pydirectinput.click(mouse_x, mouse_y)
 
-            return None
+            return True
 
         if decision == 2:
             return None
@@ -282,12 +286,14 @@ class PuzzleBot:
         if self.state == 4:
 
             if time() - self.timer_action > timep:
+                crop_image = self.get_image()
+                self.new_piece = self.get_new_piece_color(crop_image)
                 self.state = 5
                 self.timer_action = time()
-                self.new_piece = self.get_new_piece_color(crop_image)
 
         if self.state == 5:
             if time() - self.timer_action > timep:
+                crop_image = self.get_image()
                 self.timer_action = time()
                 self.set_puzzle_state(crop_image)
                 if self.play_game():

--- a/tetris.py
+++ b/tetris.py
@@ -36,11 +36,11 @@ class Tetris:
 
     def count_zeros(self):
         total = 0
-        for i in self.board:
-            for l in self.board:
-                total += 1
-
-        return 24 - total
+        for row in self.board:
+            for cell in row:
+                if cell == 0:
+                    total += 1
+        return total
 
     def verify_end(self):
 


### PR DESCRIPTION
This pull request fixes a few issues in the puzzle bot logic.

Changes:
- refresh the puzzle screenshot before reading the new piece color in state 4
- refresh the puzzle screenshot again before rebuilding the puzzle board in state 5
- fix the empty-cell counting logic in `tetris.py`
- use the correct return value when a move is successfully placed in `play_game()`

Why:
The previous implementation could work with stale screenshots and could also treat a successful move as a failed one. That could lead to wrong board detection, incorrect state transitions, and clicks outside the intended puzzle area.

I tested the logic flow locally and the changes are meant to make the puzzle state machine more reliable.